### PR TITLE
2fa resolver: use 'required_data' only to determine actions neeeding HWW resolution

### DIFF
--- a/app/src/main/java/com/greenaddress/gdk/GDKTwoFactorCall.java
+++ b/app/src/main/java/com/greenaddress/gdk/GDKTwoFactorCall.java
@@ -64,7 +64,7 @@ public class GDKTwoFactorCall {
                 case "resolve_code":
                     Log.d("RSV", "resolve_code " + mStatus);
                     final String value;
-                    if (mStatus.getDevice() != null && mStatus.getRequiredData() != null) {
+                    if (mStatus.getRequiredData() != null) {
                         try {
                             value = hardwareResolver.requestDataFromDeviceV3(mStatus.getRequiredData()).blockingGet();
                         } catch (final Exception e) {

--- a/crypto/src/main/java/com/blockstream/gdk/AuthHandler.kt
+++ b/crypto/src/main/java/com/blockstream/gdk/AuthHandler.kt
@@ -78,7 +78,7 @@ class AuthHandler(
 
                     }
                     RESOLVE_CODE -> {
-                        if(twoFactorStatus.device == null || twoFactorStatus.requiredData == null){
+                        if(twoFactorStatus.requiredData == null){
                             twoFactorResolver?.also {
                                 try {
                                     resolveCode(it.getCode(twoFactorStatus.method, twoFactorStatus.attemptsRemaining).blockingGet())

--- a/crypto/src/main/java/com/greenaddress/greenapi/data/TwoFactorStatusData.java
+++ b/crypto/src/main/java/com/greenaddress/greenapi/data/TwoFactorStatusData.java
@@ -1,5 +1,6 @@
 package com.greenaddress.greenapi.data;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
@@ -9,6 +10,7 @@ import java.util.List;
 
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class TwoFactorStatusData extends JSONData {
     private String status;
     private String action;
@@ -18,7 +20,6 @@ public class TwoFactorStatusData extends JSONData {
     private String debug;
     private String error;
     private ObjectNode result;
-    private HWDeviceDetailData device;
     private HWDeviceRequiredData required_data; // FIXME: Strongly type this
 
     public String getStatus() {
@@ -83,14 +84,6 @@ public class TwoFactorStatusData extends JSONData {
 
     public void setError(final String error) {
         this.error = error;
-    }
-
-    public HWDeviceDetailData getDevice() {
-        return device;
-    }
-
-    public void setDevice(final HWDeviceDetailData device) {
-        this.device = device;
     }
 
     public HWDeviceRequiredData getRequiredData() {


### PR DESCRIPTION
Device information will be moving to required_data in due course, this change is compatible with the currently used gdk version.