### PR TITLE
Fix dead link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Blockstream Green is a non-custodial Bitcoin wallet - it allows you to safely st
 It's a mobile app available for Android and [iOS](https://github.com/Blockstream/green_ios), based on [gdk](https://github.com/blockstream/gdk), our cross-platform wallet library.
 
 We offer a variety of advanced features, such as letting our users set their own spending limits, watch-only access for observers, and our unique multisig security model.
-All of these (and more) are explained in more detail [here](https://docs.blockstream.com/green/getting-started/intro.html).
+All of these (and more) are explained in more detail [here](https://help.blockstream.com/hc/en-us/categories/900000056183-Blockstream-Green).
 
 <a href="https://f-droid.org/packages/com.greenaddress.greenbits_android_wallet/" target="_blank">
 <img src="https://f-droid.org/badge/get-it-on.png" alt="Get it on F-Droid" height="50"/></a>


### PR DESCRIPTION
https://docs.blockstream.com/green/getting-started/intro.html is dead.
I replaced it with the link you land on when following `https://docs.blockstream.com -> Blockstream Green`