### PR TITLE
fix: hide bip passphrase

### DIFF
--- a/green/src/main/res/layout/bip39_passphrase_bottom_sheet.xml
+++ b/green/src/main/res/layout/bip39_passphrase_bottom_sheet.xml
@@ -49,7 +49,7 @@
             android:layout_marginTop="32dp"
             android:layout_marginEnd="24dp"
             android:hint="@string/id_passphrase"
-            app:endIconMode="clear_text"
+            app:endIconMode="password_toggle"
             app:counterEnabled="true"
             app:counterMaxLength="100"
             app:layout_constraintEnd_toEndOf="parent"
@@ -60,7 +60,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:imeOptions="actionDone"
-                android:inputType="textNoSuggestions|textVisiblePassword"
+                android:inputType="textNoSuggestions|textPassword"
                 android:singleLine="true"
                 android:maxLength="100"
                 android:text="@={passphrase}" />


### PR DESCRIPTION
Replace the icon mode with password toggle due to passphrase being a sensitive information and someone can look over the screen and see it

Closes https://github.com/Blockstream/green_android/issues/158

![image](https://user-images.githubusercontent.com/25645122/208502876-31efc18f-7559-4dc5-9993-225e53b618d1.png)
